### PR TITLE
Stop travis from executing on deployments to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: ruby
 rvm: 2.2.5
 sudo: false
 dist: trusty
+branched:
+  except:
+    - master
 install:
  - gem install jekyll jekyll-paginate
  - nvm install 6.1


### PR DESCRIPTION
The master branch is reserved for built code, so it doesn't make sense to run it against the test suite in Travis. 